### PR TITLE
Psychic event quests/rewards update

### DIFF
--- a/static/data/quests.json
+++ b/static/data/quests.json
@@ -51,7 +51,7 @@
     "cat": "Evolve",
     "name": "Evolve a Pokémon"
   },
-  "255": {
+  "256": {
     "cat": "Evolve",
     "name": "Evolve 3 Slowpoke or Exeggute"
   },

--- a/static/data/quests.json
+++ b/static/data/quests.json
@@ -31,6 +31,14 @@
     "cat": "Catch",
     "name": "Catch 5 Pokémon with Weather Boost"
   },
+  "120": {
+    "cat": "Catch",
+    "name": "Catch 10 Psychic-Type Pokémon"
+  },
+  "121": {
+    "cat": "Catch",
+    "name": "Catch 5 Abra or Drowzee"
+  },
   "122": {
     "cat": "Catch",
     "name": "Catch a Dragon-type Pokemon"
@@ -42,6 +50,10 @@
   "255": {
     "cat": "Evolve",
     "name": "Evolve a Pokémon"
+  },
+  "255": {
+    "cat": "Evolve",
+    "name": "Evolve 3 Slowpoke or Exeggute"
   },
   "269": {
     "cat": "Evolve",

--- a/static/data/rewards.json
+++ b/static/data/rewards.json
@@ -75,6 +75,10 @@
     "cat": "Pokémon:",
     "name": "Dratini"
   },
+  "203": {
+    "cat": "Pokémon:",
+    "name": "Girafarig"
+  },
   "224": {
     "cat": "Pokémon:",
     "name": "Octillery"


### PR DESCRIPTION
as per title, added Girafarig to rewards and quests Catch 10 Psychic-type Pokémon, Evolve 3 Slowpoke or Exeggcute, Catch 5 Abra or Drowzee --> Jynx (seen a lot)

As per Reddit post https://www.reddit.com/r/TheSilphRoad/comments/9lpqud/psychic_event_field_research_mega_thread/ no removal of quests necessary 