### PR TITLE
Add mon assigned to gym icons

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1236,7 +1236,9 @@ function customizePokemonMarker(marker, item, skipNotification) {
 
     addListeners(marker)
 }
-
+function getGymLevel(item) {
+    return 6 - item['slots_available']
+}
 function getGymMarkerIcon(item) {
     var park = item['park']
     var level = item.raid_level
@@ -1258,10 +1260,10 @@ function getGymMarkerIcon(item) {
     }
     var team = item.team_id
     var teamStr = ''
-    if (team === 0 || level === null) {
+    if (team === 0) {
         teamStr = gymTypes[item['team_id']]
     } else {
-        teamStr = gymTypes[item['team_id']] + '_' + level
+        teamStr = gymTypes[item['team_id']] + '_' + getGymLevel(item)
     }
     var exIcon = ''
     var fortMarker = ''


### PR DESCRIPTION
Current gym icons were either blank or incorrectly had a 6. Made this fix and now gyms properly display mon assigned at gyms.