### PR TITLE
Fix OSX with Apache error

### DIFF
--- a/pre-index.php
+++ b/pre-index.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 if ( ! file_exists( 'config/config.php' ) ) {
     http_response_code( 500 );
     die( "<h1>Config file missing</h1><p>Please ensure you have created your config file (<code>config/config.php</code>).</p>" );
@@ -1612,6 +1613,7 @@ if ( $blockIframe ) {
     var noConvertPortal = <?php echo $noConvertPortal === true ? 'true' : 'false' ?>;
     var markPortalsAsNew = <?php echo $markPortalsAsNew ?>;
     var copyrightSafe = <?php echo $copyrightSafe === true ? 'true' : 'false' ?>;
+    ob_end_flush();
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 <script src="static/dist/js/map.common.min.js"></script>

--- a/user.php
+++ b/user.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 
 include('config/config.php');
 ?>
@@ -456,6 +457,7 @@ include('config/config.php');
     } else {
         header("Location: .");
     }
+    ob_end_flush();
     ?>
 </div>
 </body>


### PR DESCRIPTION
Fix the header is already sent error that people have when discordlogin=true with OSX and Apache systems.