### PR TITLE
RDM: Use updated value from rdm instead of proto-value

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -320,7 +320,7 @@ class RDM extends Scanner
             $params[':oneLng'] = $oNeLng;
         }
         if ($tstamp > 0) {
-            $conds[] = "last_modified_timestamp > :lastUpdated";
+            $conds[] = "updated > :lastUpdated";
             $params[':lastUpdated'] = $tstamp;
         }
         if ($exEligible === "true") {


### PR DESCRIPTION
My raid-eggs show up as ?? until the page is refreshed, and I traced this back to the RDM-scanner being slower then the time-frame that raw_data is looking for changes.

Example;
The egg is hatched at 13:01, but my scanner scanned the egg first 13:05, the last_modified_timestamp will say 13:01, so the change won't be acknowledged because its "too old". Setting the value for when the record was updated by RDM remedies this and the updated egg (hatch) is sent.

Downside;
More data will be sent because the gyms-json array will be populated even when no "real" update has happened, since RDM updates when it last scanned, regardless if any data in the gym changed.

_In my opinion_ the added network data is negligible.
Perhaps another way would be to use a different time frame for looking for gym-changes, but it would have to be dynamic because of everyone using different amount of scanners, and areas, causing different latencies in scanning.. 