### PR TITLE
Add support for geojson.io stroke and fill colors

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -482,7 +482,7 @@ function buildScanPolygons() {
     $.getJSON(geoJSONfile, function (data) {
         var geoPolys = L.geoJson(data, {
             onEachFeature: function (features, featureLayer) {
-                featureLayer.setStyle({color: features.properties.stroke,fillColor: features.properties.fill}),
+                featureLayer.setStyle({color: features.properties.stroke, fillColor: features.properties.fill})
                 featureLayer.bindPopup(features.properties.name)
             }
         })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -482,6 +482,7 @@ function buildScanPolygons() {
     $.getJSON(geoJSONfile, function (data) {
         var geoPolys = L.geoJson(data, {
             onEachFeature: function (features, featureLayer) {
+                featureLayer.setStyle({color: features.properties.stroke,fillColor: features.properties.fill}),
                 featureLayer.bindPopup(features.properties.name)
             }
         })


### PR DESCRIPTION
Add support to use default geojson.io stroke and fill colors instead of everything being blue.