### PR TITLE
Shift sequence of location marker initialization for location fix.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -376,6 +376,49 @@ function initMap() { // eslint-disable-line no-unused-vars
             })
         }
     })
+
+    $selectLocationIconMarker = $('#locationmarker-style')
+
+    locationMarker = createLocationMarker()
+
+	if (Store.get('startAtUserLocation') && !locationSet) {
+		centerMapOnLocation()
+	}
+
+	if (Store.get('startAtLastLocation') && !locationSet) {
+		var position = Store.get('startAtLastLocationPosition')
+		var lat = 'lat' in position ? position.lat : centerLat
+		var lng = 'lng' in position ? position.lng : centerLng
+
+		var latlng = new L.LatLng(lat, lng)
+		locationMarker.setLatLng(latlng)
+		map.setView(latlng)
+	}
+
+    $.getJSON('static/dist/data/searchmarkerstyle.min.json').done(function (data) {
+        searchMarkerStyles = data
+        var searchMarkerStyleList = []
+
+        $.each(data, function (key, value) {
+            searchMarkerStyleList.push({
+                id: key,
+                text: value.name
+            })
+        })
+
+        $selectLocationIconMarker.select2({
+            placeholder: 'Select Location Marker',
+            data: searchMarkerStyleList,
+            minimumResultsForSearch: Infinity
+        })
+
+        $selectLocationIconMarker.on('change', function (e) {
+            Store.set('locationMarkerStyle', this.value)
+            updateLocationMarker(this.value)
+        })
+
+        $selectLocationIconMarker.val(Store.get('locationMarkerStyle')).trigger('change')
+    })
 }
 
 function toggleFullscreenMap() { // eslint-disable-line no-unused-vars
@@ -5635,49 +5678,6 @@ $(function () {
             mapData[dType] = {}
         })
         updateMap()
-    })
-
-    $selectLocationIconMarker = $('#locationmarker-style')
-
-    $.getJSON('static/dist/data/searchmarkerstyle.min.json').done(function (data) {
-        searchMarkerStyles = data
-        var searchMarkerStyleList = []
-
-        $.each(data, function (key, value) {
-            searchMarkerStyleList.push({
-                id: key,
-                text: value.name
-            })
-        })
-
-        locationMarker = createLocationMarker()
-
-        if (Store.get('startAtUserLocation') && !locationSet) {
-            centerMapOnLocation()
-        }
-
-        if (Store.get('startAtLastLocation') && !locationSet) {
-            var position = Store.get('startAtLastLocationPosition')
-            var lat = 'lat' in position ? position.lat : centerLat
-            var lng = 'lng' in position ? position.lng : centerLng
-
-            var latlng = new L.LatLng(lat, lng)
-            locationMarker.setLatLng(latlng)
-            map.setView(latlng)
-        }
-
-        $selectLocationIconMarker.select2({
-            placeholder: 'Select Location Marker',
-            data: searchMarkerStyleList,
-            minimumResultsForSearch: Infinity
-        })
-
-        $selectLocationIconMarker.on('change', function (e) {
-            Store.set('locationMarkerStyle', this.value)
-            updateLocationMarker(this.value)
-        })
-
-        $selectLocationIconMarker.val(Store.get('locationMarkerStyle')).trigger('change')
     })
 
     $selectGymMarkerStyle = $('#gym-marker-style')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -381,19 +381,19 @@ function initMap() { // eslint-disable-line no-unused-vars
 
     locationMarker = createLocationMarker()
 
-	if (Store.get('startAtUserLocation') && !locationSet) {
-		centerMapOnLocation()
-	}
+    if (Store.get('startAtUserLocation') && !locationSet) {
+        centerMapOnLocation()
+    }
 
-	if (Store.get('startAtLastLocation') && !locationSet) {
-		var position = Store.get('startAtLastLocationPosition')
-		var lat = 'lat' in position ? position.lat : centerLat
-		var lng = 'lng' in position ? position.lng : centerLng
+    if (Store.get('startAtLastLocation') && !locationSet) {
+        var position = Store.get('startAtLastLocationPosition')
+        var lat = 'lat' in position ? position.lat : centerLat
+        var lng = 'lng' in position ? position.lng : centerLng
 
-		var latlng = new L.LatLng(lat, lng)
-		locationMarker.setLatLng(latlng)
-		map.setView(latlng)
-	}
+        var latlng = new L.LatLng(lat, lng)
+        locationMarker.setLatLng(latlng)
+        map.setView(latlng)
+    }
 
     $.getJSON('static/dist/data/searchmarkerstyle.min.json').done(function (data) {
         searchMarkerStyles = data


### PR DESCRIPTION
There's a race condition between `initMap()` and the `ready` function where it sets the change events on all the dropdowns.  The block of code to initialize the _Settings > Style > Location Icon Marker_ dropdown was executing before `initMap()` but that block of code required `markersnotify` to be set first (dependency). 
 Sometimes `intiMap()` would execute first, most of the times the `ready` block executes first.  As a quick fix, I simply moved that block of code to initialize the _Location Icon Marker_ from that `ready` block to the end of `initMap()` so it will always ensure `markersnotify` is set.  Feel free to adjust as necessary.l