### PR TITLE
RM-MAD: Fix Stop Invalid URL Display Error

### DIFF
--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -333,7 +333,7 @@ class RocketMap_MAD extends RocketMap
             $pokestop["latitude"] = floatval($pokestop["latitude"]);
             $pokestop["longitude"] = floatval($pokestop["longitude"]);
             $pokestop["lure_expiration"] = !empty($pokestop["lure_expiration"]) ? $pokestop["lure_expiration"] * 1000 : null;
-            $pokestop["url"] = str_replace("http://", "https://images.weserv.nl/?url=", $pokestop["url"]);
+			$pokestop["url"] = ! empty($pokestop["url"]) ? str_replace("http://", "https://images.weserv.nl/?url=", $pokestop["url"]) : null;
             $pokestop["quest_type"] = intval($pokestop["quest_type"]);
             $pokestop["quest_condition_type"] = intval($pokestop["quest_condition_type"]);
             $pokestop["quest_reward_type"] = intval($pokestop["quest_reward_type"]);


### PR DESCRIPTION
Stops with a null url are creating an invalid url causing this display error.

The other php are already using this exact code but this one was missed for some reason.

![pr-stop-image](https://user-images.githubusercontent.com/46268060/56080734-d9cb3780-5dd2-11e9-8232-15a9ea26e9db.png)
