### PR TITLE
add form to quest search

### DIFF
--- a/lib/search/Search.rdm.php
+++ b/lib/search/Search.rdm.php
@@ -47,6 +47,7 @@ class RDM extends Search
 	quest_type,
 	json_extract(json_extract(`quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_pokemon_id,
 	json_extract(json_extract(`quest_rewards`,'$[*].info.item_id'),'$[0]') AS quest_item_id, 
+    json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_formid,
 	ROUND(( 3959 * acos( cos( radians(:lat) ) * cos( radians( lat ) ) * cos( radians( lon ) - radians(:lon) ) + sin( radians(:lat) ) * sin( radians( lat ) ) ) ),2) AS distance 
 	FROM pokestop
 	WHERE :conditions
@@ -63,6 +64,8 @@ class RDM extends Search
 	    $reward['quest_pokemon_id'] = intval($reward['quest_pokemon_id']);
             $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
+	    $reward['quest_pokemon_formid'] = intval($reward['quest_pokemon_formid']);
+        $reward['name'] = substr($reward['name'], 0, 19);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);
             if($defaultUnit === "km"){
                 $reward['distance'] = round($reward['distance'] * 1.60934,2);


### PR DESCRIPTION
quest search bar doesn't show form and currently just defaults to normal. this fixes that.

also, quest search bar is still broken so re-proposing my quickie fix of shortening the gym name so that users are able to scroll through quests on mobile.