### PR TITLE
Search Result Name: Allow wrapping, configurable name length and esca…

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -372,6 +372,7 @@ $noSearchNests = true;
 $noSearchPortals = true;
 $defaultUnit = "km";                                            // mi/km
 $maxSearchResults = 10;
+$maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop/gym names in search results if longer than this value to prevent UI layout issues.
 //-----------------------------------------------
 // Community
 //-----------------------------------------------------

--- a/config/default.php
+++ b/config/default.php
@@ -372,7 +372,7 @@ $noSearchNests = true;
 $noSearchPortals = true;
 $defaultUnit = "km";                                            // mi/km
 $maxSearchResults = 10;
-$maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop/gym names in search results if longer than this value to prevent UI layout issues.
+$maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop names in reward search results if longer than this value to prevent UI layout issues
 //-----------------------------------------------
 // Community
 //-----------------------------------------------------

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -370,7 +370,7 @@ $noSearchNests = true;
 $noSearchPortals = true;
 $defaultUnit = "km";                                            // mi/km
 $maxSearchResults = 10;		//Max number of search results
-$maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop/gym names in search results if longer than this value to prevent UI layout issues.
+$maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop names in reward search results if longer than this value to prevent UI layout issues
 //-----------------------------------------------
 // Community
 //-----------------------------------------------------

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -370,6 +370,7 @@ $noSearchNests = true;
 $noSearchPortals = true;
 $defaultUnit = "km";                                            // mi/km
 $maxSearchResults = 10;		//Max number of search results
+$maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop/gym names in search results if longer than this value to prevent UI layout issues.
 //-----------------------------------------------
 // Community
 //-----------------------------------------------------

--- a/lib/search/Search.monocle_mad.php
+++ b/lib/search/Search.monocle_mad.php
@@ -6,7 +6,7 @@ class Monocle_MAD extends Search
 {
     public function search_reward($lat, $lon, $term)
     {
-        global $db, $defaultUnit, $maxSearchResults;
+        global $db, $defaultUnit, $maxSearchResults, $maxSearchNameLength;
 
 	$conds = array();
 	$params = array();
@@ -65,7 +65,7 @@ class Monocle_MAD extends Search
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);
-        $reward['name'] = substr($reward['name'], 0, 19);
+	    $reward['name'] = ($maxSearchNameLength > 0) ? htmlspecialchars(substr($reward['name'], 0, $maxSearchNameLength)) : htmlspecialchars($reward['name']);
             if($defaultUnit === "km"){
                 $reward['distance'] = round($reward['distance'] * 1.60934,2);
 	    }

--- a/lib/search/Search.monocle_pmsf.php
+++ b/lib/search/Search.monocle_pmsf.php
@@ -6,7 +6,7 @@ class Monocle_PMSF extends Search
 {
     public function search_reward($lat, $lon, $term)
     {
-        global $db, $defaultUnit, $maxSearchResults;
+        global $db, $defaultUnit, $maxSearchResults, $maxSearchNameLength;
 
 	$conds = array();
 	$params = array();
@@ -64,7 +64,7 @@ class Monocle_PMSF extends Search
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);
-        $reward['name'] = substr($reward['name'], 0, 19);
+	    $reward['name'] = ($maxSearchNameLength > 0) ? htmlspecialchars(substr($reward['name'], 0, $maxSearchNameLength)) : htmlspecialchars($reward['name']);
             if($defaultUnit === "km"){
                 $reward['distance'] = round($reward['distance'] * 1.60934,2);
 	    }

--- a/lib/search/Search.rdm.php
+++ b/lib/search/Search.rdm.php
@@ -6,7 +6,7 @@ class RDM extends Search
 {
     public function search_reward($lat, $lon, $term)
     {
-        global $db, $defaultUnit, $maxSearchResults;
+        global $db, $defaultUnit, $maxSearchResults, $maxSearchNameLength;
 
 	$conds = array();
 	$params = array();
@@ -64,7 +64,7 @@ class RDM extends Search
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);
-        $reward['name'] = substr($reward['name'], 0, 19);
+	    $reward['name'] = ($maxSearchNameLength > 0) ? htmlspecialchars(substr($reward['name'], 0, $maxSearchNameLength)) : htmlspecialchars($reward['name']);
             if($defaultUnit === "km"){
                 $reward['distance'] = round($reward['distance'] * 1.60934,2);
 	    }

--- a/lib/search/Search.rocketmap_mad.php
+++ b/lib/search/Search.rocketmap_mad.php
@@ -6,7 +6,7 @@ class RocketMap_MAD extends Search
 {
     public function search_reward($lat, $lon, $term)
     {
-        global $db, $defaultUnit, $maxSearchResults;
+        global $db, $defaultUnit, $maxSearchResults, $maxSearchNameLength;
 
 	$conds = array();
 	$params = array();
@@ -65,7 +65,7 @@ class RocketMap_MAD extends Search
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);
-        $reward['name'] = substr($reward['name'], 0, 19);
+	    $reward['name'] = ($maxSearchNameLength > 0) ? htmlspecialchars(substr($reward['name'], 0, $maxSearchNameLength)) : htmlspecialchars($reward['name']);
             if($defaultUnit === "km"){
                 $reward['distance'] = round($reward['distance'] * 1.60934,2);
 	    }

--- a/static/sass/layout/_main.scss
+++ b/static/sass/layout/_main.scss
@@ -102,7 +102,7 @@ i.fa.fa-expand {
   .search-result{
     .name{
       max-width: 250px;
-      white-space: nowrap;
+      white-space: normal;
       overflow: hidden;
       text-overflow: ellipsis;
       @media(max-width:768px){


### PR DESCRIPTION
…ping name fix.

First, we allow `name` to wrap (CSS was `nowrap`). The distance was already wrapping to the 2nd line in many cases and doing this allows about 60 characters total (name + distance) on 2 lines. Testing an extra long name of 62 chars, it simply rolls over to a 3rd line preserving the layout only adding a white bar at the top and bottom of the POI's image which is is an acceptable behavior for complete information and, if you don’t like it, read the next point.

Second, we add a user configurable variable to set the max `name` length with a default of 0 (no limit). Neither I nor the users I have surveyed have encountered an inability to scroll the search results even if the layout was broken due to longer names. Regardless, this allows any admin to configure their front-end as they want. All on 1 line shortening to 19-20 chars? Sure! Complete name but sometimes on 3 lines? No problem! A good middle ground of ~45 chars to keep it to 2 lines? Why not!

Third, during my early testing using the static `substr` to 19, I was encountering random «check your connection» red box depending on my search input and changing it to 20 allowed some previous errors to return proper results while it also introduced errors for other searches. It turns out the issue is dependent on the actual name of the POI where `substr` would sometimes return a string that break the JavaScript while processing the results. Simply escaping the string solved this issue.

I feel this is a much better and cleaner solution to the problem some encountered and allows the admin to customize the display exactly as they want it.

### WHY STATIC SUBSTR TO 19 IS A HORRIBLE IDEA:

Example:

```
1234567890123456789
Modules de jeux du parc SomeName
Modules de jeux du parc SomeOtherName
Modules de jeux du parc YetADifferentParkName!
Jeux Aquatiques du parc SomeName
Terrain de Soccer XYZ du parc SomeName
```

Would display:
`Modules de jeux du `
`Modules de jeux du `
`Modules de jeux du `
`Jeux Aquatiques du `
`Terrain de Soccer X`

Those are only some of the common nomenclature in French and, unless you can recognize the image, you have no way to quickly know where the reward is without further interactions.