### PR TITLE
WIP: Reward Search: Add Pokémon Form Images

### DIFF
--- a/lib/search/Search.monocle_mad.php
+++ b/lib/search/Search.monocle_mad.php
@@ -47,6 +47,7 @@ class Monocle_MAD extends Search
 	tq.quest_type,
 	tq.quest_pokemon_id,
 	tq.quest_item_id,
+	json_extract(json_extract(`quest_reward`,'$[*].pokemon_encounter.pokemon_display.form_value'),'$[0]') AS quest_pokemon_formid,
 	ROUND(( 3959 * acos( cos( radians(:lat) ) * cos( radians( lat ) ) * cos( radians( lon ) - radians(:lon) ) + sin( radians(:lat) ) * sin( radians( lat ) ) ) ),2) AS distance 
 	FROM pokestops p
 	LEFT JOIN trs_quest tq ON tq.GUID = p.external_id
@@ -62,6 +63,7 @@ class Monocle_MAD extends Search
 	foreach($rewards as $reward){
         $reward['pokemon_name'] = !empty($reward['pokemon_name']) ? $prewardsjson[$reward['quest_pokemon_id']]['name'] : null;
 	    $reward['quest_pokemon_id'] = intval($reward['quest_pokemon_id']);
+        $reward['quest_pokemon_formid'] = intval($reward['quest_pokemon_formid']);
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);

--- a/lib/search/Search.monocle_pmsf.php
+++ b/lib/search/Search.monocle_pmsf.php
@@ -46,6 +46,7 @@ class Monocle_PMSF extends Search
 	url,
 	quest_type,
 	json_extract(json_extract(`quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_pokemon_id,
+	json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_formid,
 	json_extract(json_extract(`quest_rewards`,'$[*].info.item_id'),'$[0]') AS quest_item_id, 
 	ROUND(( 3959 * acos( cos( radians(:lat) ) * cos( radians( lat ) ) * cos( radians( lon ) - radians(:lon) ) + sin( radians(:lat) ) * sin( radians( lat ) ) ) ),2) AS distance 
 	FROM pokestops
@@ -61,6 +62,7 @@ class Monocle_PMSF extends Search
 	foreach($rewards as $reward){
         $reward['pokemon_name'] = !empty($reward['pokemon_name']) ? $prewardsjson[$reward['quest_pokemon_id']]['name'] : null;
 	    $reward['quest_pokemon_id'] = intval($reward['quest_pokemon_id']);
+        $reward['quest_pokemon_formid'] = intval($reward['quest_pokemon_formid']);
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);

--- a/lib/search/Search.rdm.php
+++ b/lib/search/Search.rdm.php
@@ -47,6 +47,7 @@ class RDM extends Search
 	quest_type,
 	json_extract(json_extract(`quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_pokemon_id,
 	json_extract(json_extract(`quest_rewards`,'$[*].info.item_id'),'$[0]') AS quest_item_id, 
+	json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_formid,
 	ROUND(( 3959 * acos( cos( radians(:lat) ) * cos( radians( lat ) ) * cos( radians( lon ) - radians(:lon) ) + sin( radians(:lat) ) * sin( radians( lat ) ) ) ),2) AS distance 
 	FROM pokestop
 	WHERE :conditions
@@ -61,6 +62,7 @@ class RDM extends Search
 	foreach($rewards as $reward){
         $reward['pokemon_name'] = !empty($reward['pokemon_name']) ? $prewardsjson[$reward['quest_pokemon_id']]['name'] : null;
 	    $reward['quest_pokemon_id'] = intval($reward['quest_pokemon_id']);
+        $reward['quest_pokemon_formid'] = intval($reward['quest_pokemon_formid']);
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);

--- a/lib/search/Search.rocketmap_mad.php
+++ b/lib/search/Search.rocketmap_mad.php
@@ -47,6 +47,7 @@ class RocketMap_MAD extends Search
 	tq.quest_type,
 	tq.quest_pokemon_id,
 	tq.quest_item_id,
+	json_extract(json_extract(`quest_reward`,'$[*].pokemon_encounter.pokemon_display.form_value'),'$[0]') AS quest_pokemon_formid,
 	ROUND(( 3959 * acos( cos( radians(:lat) ) * cos( radians( latitude ) ) * cos( radians( longitude ) - radians(:lon) ) + sin( radians(:lat) ) * sin( radians( latitude ) ) ) ),2) AS distance 
 	FROM pokestop p
 	LEFT JOIN trs_quest tq ON tq.GUID = p.pokestop_id
@@ -62,6 +63,7 @@ class RocketMap_MAD extends Search
 	foreach($rewards as $reward){
         $reward['pokemon_name'] = !empty($reward['pokemon_name']) ? $prewardsjson[$reward['quest_pokemon_id']]['name'] : null;
 	    $reward['quest_pokemon_id'] = intval($reward['quest_pokemon_id']);
+        $reward['quest_pokemon_formid'] = intval($reward['quest_pokemon_formid']);
         $reward['item_name'] = !empty($reward['item_name']) ? $irewardsjson[$reward['quest_item_id']]['name'] : null;
 	    $reward['quest_item_id'] = intval($reward['quest_item_id']);
 	    $reward['url'] = str_replace("http://", "https://images.weserv.nl/?url=", $reward['url']);

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2831,7 +2831,7 @@ function searchForItem(lat, lon, term, type, field) {
                         pokemonIdStr = element.quest_pokemon_id
                     }
                     var formStr = ''
-                    if (element.quest_pokemon_formid  === 0) {
+                    if (element.quest_pokemon_formid === 0) {
                         formStr = '00'
                     } else {
                         formStr = element.quest_pokemon_formid

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2830,6 +2830,12 @@ function searchForItem(lat, lon, term, type, field) {
                     } else {
                         pokemonIdStr = element.quest_pokemon_id
                     }
+                    var formStr = ''
+                    if (element.quest_pokemon_formid  === 0) {
+                        formStr = '00'
+                    } else {
+                        formStr = element.quest_pokemon_formid
+                    }
                     var scanArea
                     var latlng = turf.point([element.lon, element.lat])
                     $.each(scanAreas, function (index, poly) {
@@ -2842,7 +2848,7 @@ function searchForItem(lat, lon, term, type, field) {
                     var html = '<li class="search-result ' + type + '" data-lat="' + element.lat + '" data-lon="' + element.lon + '"><div class="left-column" onClick="centerMapOnCoords(event);">'
                     if (sr.hasClass('reward-results')) {
                         if (element.quest_pokemon_id !== 0) {
-                            html += '<span style="background:url(' + iconpath + 'pokemon_icon_' + pokemonIdStr + '_00.png) no-repeat;" class="i-icon" ></span>'
+                            html += '<span style="background:url(' + iconpath + 'pokemon_icon_' + pokemonIdStr + '_' + formStr + '.png) no-repeat;" class="i-icon" ></span>'
                         }
                         if (element.quest_item_id !== 0) {
                             html += '<span style="background:url(' + iconpath + 'rewards/reward_' + element.quest_item_id + '_1.png) no-repeat;" class="i-icon" ></span>'


### PR DESCRIPTION
**AS LONG AS THE QUERIES IN THE LATEST DEVELOP ARE CORRECT, THIS WILL POPULATE THE FORM VARIABLE PROPERLY BUT IT NEEDS TO BE TESTED/CONFIRMED WORKING BEFORE MERGE.**

**CONFIRM WORKING**: MAD(RocketMap db)
**UNCONFIRMED**: Monocle db and RDM db

Reward searches were not querying the database for the form value and the frontend was using a static `_00` to display the images. This is mainly the same fix I have been using in my fork for a while.

Reusing the queries available in the latest develop branch, it’ll now fetch the information and put the value in `quest_pokemon_formid` since that’s the name used for the regular stops queries for the same purpose.

The frontend is modified to use that value in exactly the same way used for the pokéstop display.