### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+## Simple Dockerfile to build PMSF (develop branch) 
+# - The base image can be found here: https://github.com/thecodingmachine/docker-images-php
+# - Inside the container, the content of this git repo lives in /var/www/html/
+## You have to mount your configs into the container:  
+# - mount config.php to /var/www/html/config/config.php
+# - mount access-config.php to /var/www/html/config/access-config.php
+# - Also mount every other configuration file necessary into the according directory.
+
+FROM thecodingmachine/php:7.2-v1-apache-node10
+
+RUN git clone https://github.com/whitewillem/PMSF.git /var/www/html/ && git checkout develop
+RUN npm install
+RUN npm run build


### PR DESCRIPTION
This PR adds a Dockerfile to build a docker-image for PMSF (develop branch). 

- The base image can be found here: https://github.com/thecodingmachine/docker-images-php
- Inside the container, the content of this git repo lives in `/var/www/html/`

You have to mount your configs into the container:  
- mount `config.php` to `/var/www/html/config/config.php`
- mount `access-config.php` to `/var/www/html/config/access-config.php`
- Also mount every other configuration file necessary into the according directory.

You change back the Apache user and group to www-data and create the cron-jobs in the container by setting an environment file, e.g. `env.conf`:

```
# Change back Apache user and group to www-data
APACHE_RUN_USER=www-data
APACHE_RUN_GROUP=www-data
# configure the user that will run cron (defaults to root
CRON_USER_1=root
# configure the schedule for the cron job (here: run every minute)
CRON_SCHEDULE_1=* * * * *
# last but not least, configure the command
CRON_COMMAND_1=php /var/www/html/cron/raid_cron.php
# job 2
CRON_USER_2=root
CRON_SCHEDULE_2=15 0 * * *
CRON_COMMAND_2=php /var/www/html/cron/quest_cron.php
# job 3
CRON_USER_3=root
CRON_SCHEDULE_3=0 * * * *
CRON_COMMAND_3=php /var/www/html/cron/silph.php
# job 4
CRON_USER_4=root
CRON_SCHEDULE_4=0 2 * * 4
CRON_COMMAND_4=php /var/www/html/cron/nest_cron.php
```