### PR TITLE
Log discord loginexception

### DIFF
--- a/discord-callback.php
+++ b/discord-callback.php
@@ -67,7 +67,9 @@ if ($noDiscordLogin === false) {
         }
         die();
     } catch (Exception $e) {
-        header("Location: ./discord-login");
+        error_log("Unexpected error after Discord Auth!");
+        error_log($e);
+        header("Location: ./?login=false&exception=yes");
     }
 } else {
     header("Location: .");


### PR DESCRIPTION
Don't redirect back to discord-auth after we failed to login because of an exception. 
Also log the exception into the errorlog for debugging