### PR TITLE
FiX: MAD Verified/Unverified.

### DIFF
--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -175,7 +175,7 @@ class RocketMap_MAD extends RocketMap
         foreach ($pokemons as $pokemon) {
             $pokemon["latitude"] = floatval($pokemon["latitude"]);
             $pokemon["longitude"] = floatval($pokemon["longitude"]);
-            $pokemon["expire_timestamp_verified"] = floatval($pokemon["expire_timestamp_verified"]);
+            $pokemon["expire_timestamp_verified"] = isset($pokemon["expire_timestamp_verified"]) ? 1 : null;
             $pokemon["disappear_time"] = $pokemon["disappear_time"] * 1000;
 
             $pokemon["weight"] = isset($pokemon["weight"]) ? floatval($pokemon["weight"]) : null;

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -991,7 +991,7 @@ function pokemonLabel(item) {
         contentstring += '_' + item['costume']
     }
     contentstring += '.png" style="width:50px;margin-top:10px;"/>'
-    if (item['expire_timestamp_verified'] !== 0 && item['expire_timestamp_verified'] !== '0') {
+    if (item['expire_timestamp_verified'] > 0) {
         contentstring += '<b style="top:-20px;position:relative;">' +
             '<i class="far fa-clock"></i>' + ' ' + getTimeStr(disappearTime) +
             ' <span class="label-countdown" disappears-at="' + disappearTime + '">(00m00s)</span>' +


### PR DESCRIPTION
INFO:
MAD's `calc_endminsec` format is either `null` (unverified) or `MM:SS` (verified) representing the despawn minute and second.

BUG:
`expire_timestamp_verified` is currently assigned using `floatval($pokemon["expire_timestamp_verified"])` which, on a value of 00:17, results in a value of `0` which is later interpreted as unverified (wrong).

FIX:
The actual value doesn't appear to used for anything so assigning a value of `1` (or higher) if verified and `null` (or 0) if unverified solves the issue while remaining compatible with the current logic in `map.js` and without adding a special condition.