### PR TITLE
don't confuse discord users

### DIFF
--- a/pre-index.php
+++ b/pre-index.php
@@ -1398,7 +1398,7 @@ if ($blockIframe) {
             </div>
             <div><center><p>
                 <?php
-                if ((! $noSelly) && $_SESSION['user']->login_system === native) {
+                if (! $noSelly && $_SESSION['user']->login_system === native) {
                     $time = date("Y-m-d", $_SESSION['user']->expire_timestamp);
                 
                     if ($_SESSION['user']->expire_timestamp > time()) {

--- a/pre-index.php
+++ b/pre-index.php
@@ -1398,7 +1398,7 @@ if ($blockIframe) {
             </div>
             <div><center><p>
                 <?php
-                if (! $noSelly) {
+                if ((! $noSelly) && $_SESSION['user']->login_system === native) {
                     $time = date("Y-m-d", $_SESSION['user']->expire_timestamp);
                 
                     if ($_SESSION['user']->expire_timestamp > time()) {


### PR DESCRIPTION
don't display expire timestamp for discord users if you're running discord and native login concurrently.