### PR TITLE
Don't always return scan locations if enabled in config and disabled …

### DIFF
--- a/raw_data.php
+++ b/raw_data.php
@@ -44,6 +44,7 @@ $lastcommunities = !empty($_POST['lastcommunities']) ? $_POST['lastcommunities']
 $lastportals = !empty($_POST['lastportals']) ? $_POST['lastportals'] : false;
 $lastpois = !empty($_POST['lastpois']) ? $_POST['lastpois'] : false;
 $exEligible = !empty($_POST['exEligible']) ? $_POST['exEligible'] : false;
+$d["lastscanlocations"] = !empty($_POST['scanlocations']) ? $_POST['scanlocations'] : false;
 $d["lastpokestops"] = !empty($_POST['pokestops']) ? $_POST['pokestops'] : false;
 $d["lastgyms"] = !empty($_POST['gyms']) ? $_POST['gyms'] : false;
 $d["lastslocs"] = !empty($_POST['scanned']) ? $_POST['scanned'] : false;
@@ -307,11 +308,13 @@ $debug['5_after_spawnpoints'] = microtime(true) - $timing['start'];
 
 global $noLiveScanLocation;
 if (!$noLiveScanLocation) {
-    if ($newarea) {
-        $d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng);
-    } else {
-        $d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, $timestamp);
-    }
+    if ($d["lastscanlocations"] == "true") {
+		if ($newarea) {
+			$d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng);
+		} else {
+			$d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, $timestamp);
+		}
+	}
 }
 
 $d['token'] = refreshCsrfToken();

--- a/raw_data.php
+++ b/raw_data.php
@@ -309,12 +309,12 @@ $debug['5_after_spawnpoints'] = microtime(true) - $timing['start'];
 global $noLiveScanLocation;
 if (!$noLiveScanLocation) {
     if ($d["lastscanlocations"] == "true") {
-		if ($newarea) {
-			$d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng);
-		} else {
-			$d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, $timestamp);
-		}
-	}
+        if ($newarea) {
+            $d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng);
+        } else {
+            $d["scanlocations"] = $scanner->get_scanlocation($swLat, $swLng, $neLat, $neLng, $timestamp);
+        }
+    }
 }
 
 $d['token'] = refreshCsrfToken();


### PR DESCRIPTION
…in frontend.

If $noLiveScanLocation was false in config, the information was always returned and ignored the frontend toggle.

This simply uses the information that was already passed in $_POST to also check the frontend’s settings to avoid an unnecessary query and save a few bytes of bandwidth.